### PR TITLE
Remove unneeded dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     ],
     "require": {
         "symfony/validator": "^4",
-        "symfony/security-core": "^4",
-        "php": ">7.0"
+        "symfony/security-core": "^4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since this package requires Symfony 4, this is not needed. SF itself already requires `"php": "^7.1.3"`.