### PR TITLE
Password may not contain username

### DIFF
--- a/src/Constraints/PasswordValidator.php
+++ b/src/Constraints/PasswordValidator.php
@@ -53,7 +53,7 @@ class PasswordValidator extends ConstraintValidator
                 ->addViolation();
         }
 
-        if (null !== $plainPasswordAccessor && $value->getUserName() === $stringValue) {
+        if (null !== $plainPasswordAccessor && false !== strpos($stringValue, $value->getUserName())) {
             $this->context
                 ->buildViolation($constraint->usernameMessage)
                 ->setInvalidValue($value)

--- a/tests/src/Constraints/PasswordValidatorTest.php
+++ b/tests/src/Constraints/PasswordValidatorTest.php
@@ -18,6 +18,17 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
         $this->assertSame($passwordConstraint->usernameMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
     }
 
+    public function testNotContainsUserName()
+    {
+        $user = new Symfony\Component\Security\Core\User\User('Foobarbaz1@example.com', 'HelloFoobarbaz1@example.comWorld');
+        $passwordConstraint = new Password(['plainPasswordAccessor' => 'getPassword', 'plainPasswordProperty' => 'password']);
+
+        $this->validator->validate($user, $passwordConstraint);
+
+        $this->assertSame(1, $this->context->getViolations()->count());
+        $this->assertSame($passwordConstraint->usernameMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
+    }
+
     public function testLength()
     {
         $user = new Symfony\Component\Security\Core\User\User('Foobarbaz1@example.com', 'Foo1');


### PR DESCRIPTION
With this PR, it is not allowed anymore for the password to contain the username.

Maybe should be using `strtolower` to add an extra check? 