### PR TITLE
Allow the validator to be used as a property validator as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .idea
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "symfony/validator": "^4",
-        "symfony/security-core": "^4"
+        "symfony/security-core": "^4",
+        "friendsofphp/php-cs-fixer": "^2.18"
     },
     "autoload": {
         "psr-4": {

--- a/src/Constraints/Password.php
+++ b/src/Constraints/Password.php
@@ -1,11 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PasswordValidator\Constraints;
 
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 /**
  * @Annotation
@@ -14,7 +13,6 @@ class Password extends Constraint
 {
     const TOO_SHORT_ERROR = '9ff3fdc4-b214-49db-8718-39c315e33d45';
     const TOO_LONG_ERROR = 'd94b19cc-114f-4f44-9cc4-4138e80a87b9';
-
 
     protected static $errorNames = [
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',
@@ -31,7 +29,6 @@ class Password extends Constraint
     public $plainPasswordProperty = null;
     public $max;
     public $min;
-
 
     public function __construct($options = null)
     {

--- a/src/Constraints/Password.php
+++ b/src/Constraints/Password.php
@@ -35,10 +35,6 @@ class Password extends Constraint
 
     public function __construct($options = null)
     {
-        if (!isset($options['plainPasswordAccessor']) || !isset($options['plainPasswordProperty'])) {
-            throw new MissingOptionsException('The plainPasswordAccessor and plainPasswordProperty options are required.', ['plainPasswordAccessor', 'plainPasswordProperty']);
-        }
-
         if (!isset($options['min'])) {
             $options['min'] = 8;
         }
@@ -50,8 +46,8 @@ class Password extends Constraint
         parent::__construct($options);
     }
 
-    public function getTargets(): string
+    public function getTargets(): array
     {
-        return self::CLASS_CONSTRAINT;
+        return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }
 }

--- a/src/Constraints/PasswordValidator.php
+++ b/src/Constraints/PasswordValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PasswordValidator\Constraints;
@@ -8,7 +9,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
-use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class PasswordValidator extends ConstraintValidator
 {
@@ -21,23 +21,21 @@ class PasswordValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Password) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\Password');
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Password');
         }
-
 
         if ($value instanceof UserInterface) {
             $plainPasswordAccessor = $constraint->plainPasswordAccessor;
             $this->plainPasswordProperty = $constraint->plainPasswordProperty;
 
-            if ($plainPasswordAccessor === null || $this->plainPasswordProperty === null) {
+            if (null === $plainPasswordAccessor || null === $this->plainPasswordProperty) {
                 throw new MissingOptionsException('The plainPasswordAccessor and plainPasswordProperty options are required when using the class constraint.', ['plainPasswordAccessor', 'plainPasswordProperty']);
             }
 
-            $stringValue = (string)$value->$plainPasswordAccessor();
+            $stringValue = (string) $value->$plainPasswordAccessor();
         } else {
-            $stringValue = (string)$value;
+            $stringValue = (string) $value;
         }
-
 
         $length = mb_strlen($stringValue);
 
@@ -45,9 +43,9 @@ class PasswordValidator extends ConstraintValidator
             $this->buildViolation(
                 $value,
                 $constraint->min === $constraint->max ? $constraint->exactMessage : $constraint->maxMessage,
-                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->max,]
+                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->max]
             )
-                ->setPlural((int)$constraint->max)
+                ->setPlural((int) $constraint->max)
                 ->setCode(Password::TOO_LONG_ERROR)
                 ->addViolation();
         }
@@ -55,9 +53,9 @@ class PasswordValidator extends ConstraintValidator
         if (null !== $constraint->min && $length < $constraint->min) {
             $this->buildViolation($value,
                 $constraint->min === $constraint->max ? $constraint->exactMessage : $constraint->minMessage,
-                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->min,]
+                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->min]
             )
-                ->setPlural((int)$constraint->min)
+                ->setPlural((int) $constraint->min)
                 ->setCode(Password::TOO_SHORT_ERROR)
                 ->addViolation();
         }
@@ -80,7 +78,6 @@ class PasswordValidator extends ConstraintValidator
             $this->buildViolation($value, $constraint->lowerCaseCharacterMissingMessage)->addViolation();
         }
 
-
         // Check whether there is at least one number present
         if (!\preg_match('/[0-9]/', $stringValue)) {
             $this->buildViolation($value, $constraint->numberMissingMessage)->addViolation();
@@ -90,7 +87,6 @@ class PasswordValidator extends ConstraintValidator
     private function buildViolation($value, string $message, array $parameters = [])
     {
         $isClassConstraint = $value instanceof UserInterface;
-
 
         $violation = $this->context->buildViolation($message);
         $violation->setInvalidValue($value);

--- a/src/Constraints/PasswordValidator.php
+++ b/src/Constraints/PasswordValidator.php
@@ -6,87 +6,102 @@ namespace PasswordValidator\Constraints;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class PasswordValidator extends ConstraintValidator
 {
+    /** @var string|null */
+    private $plainPasswordProperty;
+
     /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Password) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Password');
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\Password');
         }
 
-        if (!($value instanceof UserInterface)) {
-            throw new UnexpectedTypeException($value, UserInterface::class);
+
+        if ($value instanceof UserInterface) {
+            $plainPasswordAccessor = $constraint->plainPasswordAccessor;
+            $this->plainPasswordProperty = $constraint->plainPasswordProperty;
+
+            if ($plainPasswordAccessor === null || $this->plainPasswordProperty === null) {
+                throw new MissingOptionsException('The plainPasswordAccessor and plainPasswordProperty options are required when using the class constraint.', ['plainPasswordAccessor', 'plainPasswordProperty']);
+            }
+
+            $stringValue = (string)$value->$plainPasswordAccessor();
+        } else {
+            $stringValue = (string)$value;
         }
 
-        $plainPasswordAccessor = $constraint->plainPasswordAccessor;
-        $plainPasswordProperty = $constraint->plainPasswordProperty;
-
-        $stringValue = (string) $value->$plainPasswordAccessor();
 
         $length = mb_strlen($stringValue);
 
         if (null !== $constraint->max && $length > $constraint->max) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
-                ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                ->setParameter('{{ limit }}', $constraint->max)
-                ->setInvalidValue($value)
+            $this->buildViolation(
+                $value,
+                $constraint->min === $constraint->max ? $constraint->exactMessage : $constraint->maxMessage,
+                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->max,]
+            )
                 ->setPlural((int)$constraint->max)
-                ->atPath($plainPasswordProperty)
                 ->setCode(Password::TOO_LONG_ERROR)
                 ->addViolation();
         }
 
         if (null !== $constraint->min && $length < $constraint->min) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
-                ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                ->setParameter('{{ limit }}', $constraint->min)
-                ->setInvalidValue($value)
-                ->atPath($plainPasswordProperty)
+            $this->buildViolation($value,
+                $constraint->min === $constraint->max ? $constraint->exactMessage : $constraint->minMessage,
+                ['{{ value }}' => $this->formatValue($stringValue), '{{ limit }}' => $constraint->min,]
+            )
                 ->setPlural((int)$constraint->min)
                 ->setCode(Password::TOO_SHORT_ERROR)
                 ->addViolation();
         }
 
-        if (null !== $plainPasswordAccessor && false !== strpos($stringValue, $value->getUserName())) {
+        if ($value instanceof UserInterface && false !== strpos($stringValue, $value->getUserName())) {
             $this->context
                 ->buildViolation($constraint->usernameMessage)
                 ->setInvalidValue($value)
-                ->atPath($plainPasswordProperty)
+                ->atPath($this->plainPasswordProperty)
                 ->addViolation();
         }
 
         // Check whether there is at least one upper cased character present
         if (!\preg_match('/[A-Z]/', $stringValue)) {
-            $this->context
-                ->buildViolation($constraint->upperCaseCharacterMissingMessage)
-                ->setInvalidValue($value)
-                ->atPath($plainPasswordProperty)
-                ->addViolation();
+            $this->buildViolation($value, $constraint->upperCaseCharacterMissingMessage)->addViolation();
         }
 
         // Check whether there is at least one lower cased character present
         if (!\preg_match('/[a-z]/', $stringValue)) {
-            $this->context
-                ->buildViolation($constraint->lowerCaseCharacterMissingMessage)
-                ->setInvalidValue($value)
-                ->atPath($plainPasswordProperty)
-                ->addViolation();
+            $this->buildViolation($value, $constraint->lowerCaseCharacterMissingMessage)->addViolation();
         }
 
 
         // Check whether there is at least one number present
         if (!\preg_match('/[0-9]/', $stringValue)) {
-            $this->context
-                ->buildViolation($constraint->numberMissingMessage)
-                ->setInvalidValue($value)
-                ->atPath($plainPasswordProperty)
-                ->addViolation();
+            $this->buildViolation($value, $constraint->numberMissingMessage)->addViolation();
         }
+    }
+
+    private function buildViolation($value, string $message, array $parameters = [])
+    {
+        $isClassConstraint = $value instanceof UserInterface;
+
+
+        $violation = $this->context->buildViolation($message);
+        $violation->setInvalidValue($value);
+        foreach ($parameters as $parameterKey => $parameter) {
+            $violation->setParameter($parameterKey, $parameter);
+        }
+
+        if ($isClassConstraint) {
+            $violation->atPath($this->plainPasswordProperty);
+        }
+
+        return $violation;
     }
 }

--- a/tests/src/Constraints/ClassConstraintTest.php
+++ b/tests/src/Constraints/ClassConstraintTest.php
@@ -1,9 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 use PasswordValidator\Constraints\Password;
 use PasswordValidator\Constraints\PasswordValidator;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class PasswordValidatorTest extends \Symfony\Component\Validator\Test\ConstraintValidatorTestCase
@@ -39,7 +39,6 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->minMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testNumber()
@@ -62,7 +61,6 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->upperCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testLowerCase()
@@ -74,7 +72,6 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->lowerCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testProperPassword()
@@ -85,7 +82,6 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
         $this->validator->validate($user, $passwordConstraint);
         $this->assertNoViolation();
     }
-
 
     // Check whether class and property options are mixed
     public function testInvalidUserConfiguration()

--- a/tests/src/Constraints/ClassConstraintTest.php
+++ b/tests/src/Constraints/ClassConstraintTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PasswordValidator\Constraints\Password;
 use PasswordValidator\Constraints\PasswordValidator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class PasswordValidatorTest extends \Symfony\Component\Validator\Test\ConstraintValidatorTestCase
 {
@@ -83,6 +84,17 @@ class PasswordValidatorTest extends \Symfony\Component\Validator\Test\Constraint
 
         $this->validator->validate($user, $passwordConstraint);
         $this->assertNoViolation();
+    }
+
+
+    // Check whether class and property options are mixed
+    public function testInvalidUserConfiguration()
+    {
+        $user = new Symfony\Component\Security\Core\User\User('Foobarbaz1@example.com', 'FOOBARBAZ1@example.com');
+        $passwordConstraint = new Password();
+
+        $this->expectException(MissingOptionsException::class);
+        $this->validator->validate($user, $passwordConstraint);
     }
 
     protected function createValidator()

--- a/tests/src/Constraints/PasswordTest.php
+++ b/tests/src/Constraints/PasswordTest.php
@@ -7,18 +7,6 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class PasswordTest extends TestCase
 {
-    public function testConstructionWithoutAccessor()
-    {
-        $this->expectException(MissingOptionsException::class);
-        new Password(['plainPasswordProperty' => 'foo']);
-    }
-
-    public function testConstructionWithoutFieldDefinition()
-    {
-        $this->expectException(MissingOptionsException::class);
-        new Password(['plainPasswordAccessor' => 'getFoo']);
-    }
-
     public function testConstructionWithProperParameters()
     {
         $this->assertInstanceOf(Password::class, new Password(['plainPasswordAccessor' => 'getFoo', 'plainPasswordProperty' => 'foo']));

--- a/tests/src/Constraints/PasswordTest.php
+++ b/tests/src/Constraints/PasswordTest.php
@@ -1,9 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 use PasswordValidator\Constraints\Password;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class PasswordTest extends TestCase
 {

--- a/tests/src/Constraints/PropertyConstraintTest.php
+++ b/tests/src/Constraints/PropertyConstraintTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use PasswordValidator\Constraints\Password;
@@ -15,7 +16,6 @@ class PropertyConstraintTest extends \Symfony\Component\Validator\Test\Constrain
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->minMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testNumber()
@@ -37,7 +37,6 @@ class PropertyConstraintTest extends \Symfony\Component\Validator\Test\Constrain
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->upperCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testLowerCase()
@@ -49,7 +48,6 @@ class PropertyConstraintTest extends \Symfony\Component\Validator\Test\Constrain
 
         $this->assertSame(1, $this->context->getViolations()->count());
         $this->assertSame($passwordConstraint->lowerCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
-
     }
 
     public function testProperPassword()

--- a/tests/src/Constraints/PropertyConstraintTest.php
+++ b/tests/src/Constraints/PropertyConstraintTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+use PasswordValidator\Constraints\Password;
+use PasswordValidator\Constraints\PasswordValidator;
+
+class PropertyConstraintTest extends \Symfony\Component\Validator\Test\ConstraintValidatorTestCase
+{
+    public function testLength()
+    {
+        $password = 'Foo1';
+        $passwordConstraint = new Password();
+
+        $this->validator->validate($password, $passwordConstraint);
+
+        $this->assertSame(1, $this->context->getViolations()->count());
+        $this->assertSame($passwordConstraint->minMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
+
+    }
+
+    public function testNumber()
+    {
+        $password = 'Foobarbaz@example.com';
+        $passwordConstraint = new Password();
+        $this->validator->validate($password, $passwordConstraint);
+
+        $this->assertSame(1, $this->context->getViolations()->count());
+        $this->assertSame($passwordConstraint->numberMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
+    }
+
+    public function testUpperCase()
+    {
+        $password = 'foobarbaz1@example.com';
+        $passwordConstraint = new Password();
+
+        $this->validator->validate($password, $passwordConstraint);
+
+        $this->assertSame(1, $this->context->getViolations()->count());
+        $this->assertSame($passwordConstraint->upperCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
+
+    }
+
+    public function testLowerCase()
+    {
+        $password = 'FOOBARBAZ1';
+        $passwordConstraint = new Password();
+
+        $this->validator->validate($password, $passwordConstraint);
+
+        $this->assertSame(1, $this->context->getViolations()->count());
+        $this->assertSame($passwordConstraint->lowerCaseCharacterMissingMessage, $this->context->getViolations()->get(0)->getMessageTemplate());
+
+    }
+
+    public function testProperPassword()
+    {
+        $password = 'FOOBARBAZ1@example.com';
+        $passwordConstraint = new Password();
+
+        $this->validator->validate($password, $passwordConstraint);
+        $this->assertNoViolation();
+    }
+
+    // Check whether class and property options are mixed
+    public function testInvalidPropertyConfiguration()
+    {
+        $password = 'FOOBARBAZ1@example.com';
+        $passwordConstraint = new Password(['plainPasswordAccessor' => 'getPassword', 'plainPasswordProperty' => 'password']);
+
+        $this->validator->validate($password, $passwordConstraint);
+        $this->assertNoViolation();
+    }
+
+    protected function createValidator()
+    {
+        return new PasswordValidator();
+    }
+}


### PR DESCRIPTION
Initial pull request to trigger workflow actions.

Feature: Allow the password constraint to be used as a property constraint, validating plain password strings
BC: Potential breakage, the options validation is looser because of the dropped requirement on password accessors
Limitations: Using the property constraint won't allow you to validate whether the password contains one's username. This should be done manually or by using the preexisting class constraint